### PR TITLE
Fix verbose arg for checker

### DIFF
--- a/main.py
+++ b/main.py
@@ -276,6 +276,6 @@ if __name__ == '__main__':
     try:
         from checker import checker
         print("\n--- Running Checker ---")
-        checker(airline_to_run, verbal=False)
+        checker(airline_to_run, verbose=False)
     except (ImportError, FileNotFoundError):
         print("\nCould not run checker.py automatically.")


### PR DESCRIPTION
## Summary
- call `checker` with `verbose=False` in `main.py`

## Testing
- `python -m py_compile main.py checker.py params.py`

------
https://chatgpt.com/codex/tasks/task_e_68446733c994832f9f8e2c20b87e44dc